### PR TITLE
Upgraded mailparser version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-admin-sdk",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "node.js library that wraps the Directory and Groups APIs in the Google Admin SDK",
   "main": "./index.js",
   "directories": {
@@ -23,7 +23,7 @@
     "coffee-script": "^1.9.0",
     "dotty": "0.0.2",
     "http-string-parser": "0.0.4",
-    "mailparser": "^0.4.8",
+    "mailparser": "^0.6.2 ",
     "qs": "^2.3.3",
     "quest": "^0.2.8",
     "retry": "^0.6.1",


### PR DESCRIPTION
This version of mailparser, uses a specific version of `mime`: https://github.com/nodemailer/mailparser/blob/b8488c5b6a73920b58bcd2f62a5c3be115940fe4/package.json#L22 (mailparser@v0.6.2)

Opposed to just using `*`: https://github.com/nodemailer/mailparser/blob/c9f0fd2e6bec8291e2ad7f6e420fd2d4f9973a0e/package.json#L29 (mailparser@v0.4.8)