### PR TITLE
Move off deprecated Google batch endpoint

### DIFF
--- a/lib/batch.coffee
+++ b/lib/batch.coffee
@@ -38,7 +38,7 @@ class Batch
 
         options =
           method: 'post'
-          uri: "https://www.googleapis.com/batch"
+          uri: "https://www.googleapis.com/batch/admin/directory_v1"
           body: request_body
           headers:
             Authorization: "Bearer #{@google_api.options.token.access}"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-admin-sdk",
-  "version": "4.1.2",
+  "version": "4.2.0",
   "description": "node.js library that wraps the Directory and Groups APIs in the Google Admin SDK",
   "main": "./index.js",
   "directories": {

--- a/test/google_batch.coffee
+++ b/test/google_batch.coffee
@@ -96,7 +96,7 @@ describe 'Batch Requests', ->
       .get('/oauth2/v1/tokeninfo?access_token=fake_access_token')
       .reply(200, "OK")
       .filteringRequestBody(@boundary_filter)
-      .post('/batch', expected_request)
+      .post('/batch/admin/directory_v1', expected_request)
       .reply 200, expected_reply,
         { 'content-type': 'multipart/mixed; boundary=batch_7av0UPcSyII=_ABKN5zORmiQ=' }
 
@@ -148,7 +148,7 @@ describe 'Batch Requests', ->
       .get('/oauth2/v1/tokeninfo?access_token=fake_access_token')
       .reply(200, "OK")
       .filteringRequestBody(@boundary_filter)
-      .post('/batch', expected_request)
+      .post('/batch/admin/directory_v1', expected_request)
       .reply 200, expected_reply,
         { 'content-type': 'multipart/mixed; boundary=batch_7av0UPcSyII=_ABKN5zORmiQ=' }
 
@@ -166,7 +166,7 @@ describe 'Batch Requests', ->
     nock('https://www.googleapis.com:443')
       .get('/oauth2/v1/tokeninfo?access_token=fake_access_token')
       .reply(200, "OK")
-      .post('/batch')
+      .post('/batch/admin/directory_v1')
       .reply 404, "We accidently rimraf"
 
     batch = new google_apis.Batch @options
@@ -195,11 +195,11 @@ describe 'Batch Requests', ->
       .get('/oauth2/v1/tokeninfo?access_token=fake_access_token')
       .reply(200, "OK")
       .filteringRequestBody(@boundary_filter)
-      .post('/batch', expected_request)
+      .post('/batch/admin/directory_v1', expected_request)
       .reply(503, 'Enhance your calm')
-      .post('/batch', expected_request)
+      .post('/batch/admin/directory_v1', expected_request)
       .reply(503, 'Enhance your calm')
-      .post('/batch', expected_request)
+      .post('/batch/admin/directory_v1', expected_request)
       .reply 200, expected_reply,
         { 'content-type': 'multipart/mixed; boundary=batch_7av0UPcSyII=_ABKN5zORmiQ=' }
 


### PR DESCRIPTION
https://clever.atlassian.net/browse/SYNC-448

Following instructions here: https://developers.googleblog.com/2018/03/discontinuing-support-for-json-rpc-and.html

I called their discovery API and it looks like this is the one we want:
```
{
   "kind": "discovery#directoryItem",
   "id": "admin:directory_v1",
   "name": "admin",
   "version": "directory_v1",
   "title": "Admin Directory API",
   "description": "Manages enterprise resources such as users and groups, administrative notifications, security features, and more.",
   "discoveryRestUrl": "https://www.googleapis.com/discovery/v1/apis/admin/directory_v1/rest",
   "discoveryLink": "./apis/admin/directory_v1/rest",
   "icons": {
    "x16": "https://www.gstatic.com/images/branding/product/1x/googleg_16dp.png",
    "x32": "https://www.gstatic.com/images/branding/product/1x/googleg_32dp.png"
   },
   "documentationLink": "https://developers.google.com/admin-sdk/directory/",
   "preferred": false
  },
```

So I added in `/admin/district_v1` as per the instructions to change the endpoint from `www.googleapis.com/batch` to `www.googleapis.com/batch/<api>/<version>`.